### PR TITLE
Fix pickle overflow

### DIFF
--- a/reference/src/main/python/similar.py
+++ b/reference/src/main/python/similar.py
@@ -355,7 +355,7 @@ def counter_vectorize(rpath, wpath):
     vectorizer = CountVectorizer(min_df=1, binary=True)
     counter_matrix = vectorizer.fit_transform(documents)
     with open(wpath, "wb") as outf:
-        pickle.dump((vectorizer, counter_matrix), outf)
+        pickle.dump((vectorizer, counter_matrix), outf, protocol=4)
 
 
 def read_all_records(rpath):


### PR DESCRIPTION
Fixes following error if running experiment on large number of repos.
Traceback (most recent call last):
  File "src/main/python/similar.py", line 1044, in <module>
    setup(options.corpus)
  File "src/main/python/similar.py", line 1037, in setup
    os.path.join(options.working_dir, config.TFIDF_FILE),
  File "src/main/python/similar.py", line 358, in counter_vectorize
    pickle.dump((vectorizer, counter_matrix), outf)
OverflowError: cannot serialize a bytes object larger than 4 GiB

Ref: https://stackoverflow.com/questions/29704139/pickle-in-python3-doesnt-work-for-large-data-saving